### PR TITLE
Add bottom margin to diary entries so they aren't hidden - Fixes #13

### DIFF
--- a/app/src/main/res/layout/diary_fragment.xml
+++ b/app/src/main/res/layout/diary_fragment.xml
@@ -16,7 +16,8 @@
         <androidx.recyclerview.widget.RecyclerView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/diaryRecyclerView"/>
+            android:id="@+id/diaryRecyclerView"
+            android:paddingBottom="100dp"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
I added some margin on the bottom of the diary entries `RecyclerView` so the tab bar wouldn't hide the last few items.